### PR TITLE
Migrate from `go.essaim.dev` to `essaim.dev`

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-go.essaim.dev
+essaim.dev

--- a/modgen.yaml
+++ b/modgen.yaml
@@ -1,12 +1,6 @@
-host: go.essaim.dev
+host: essaim.dev
 
 modules:
-  - path: /pex
-    vcs: git
-    repo-url: https://github.com/essaim-dev/pex
   - path: /modgen
     vcs: git
     repo-url: https://github.com/essaim-dev/modgen
-  - path: /al
-    vcs: git
-    repo-url: https://github.com/essaim-dev/al


### PR DESCRIPTION
Removing the `go` prefix of the Go module vanity URL.